### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,6 +1,10 @@
 name: manual-deploy-production
 run-name: Deploy Production from ${{ inputs.ref }}
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/sunya9/vite-plugin-react-og-image/security/code-scanning/2](https://github.com/sunya9/vite-plugin-react-og-image/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, the following permissions are appropriate:
- `contents: read` for checking out the repository code.
- `packages: write` for publishing the package to npm.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`publish`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
