### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/sunya9/vite-plugin-react-og-image/security/code-scanning/3](https://github.com/sunya9/vite-plugin-react-og-image/security/code-scanning/3)

To fix the issue, add a `permissions` block to the root of the workflow file (`ci.yml`) to explicitly define the least privileges required for the workflow. Since the workflow uses another workflow (`build-and-test.yml`), the permissions should be set to `contents: read` as a minimal starting point, unless additional permissions are required for the tasks performed in the `build-and-test.yml` workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
