### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write # required for npm oidc
 
 jobs:
   release-please:
@@ -38,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
@@ -48,6 +49,4 @@ jobs:
       # build will be executed in prepublishOnly script
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Replace static `NPM_TOKEN` secret with GitHub Actions OIDC-based trusted publishing
- Add `--provenance` flag to `npm publish` for supply chain security
- Update Node.js version to 24

## Test plan
- [x] npm 側で Trusted Publishing の設定を完了する
- [x] release-please PR をマージして publish ジョブが成功することを確認する
- [x] npm パッケージに provenance バッジが表示されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)